### PR TITLE
v1.3 Dev

### DIFF
--- a/src/WetzUtilities.Test/StringExtensionsTests.cs
+++ b/src/WetzUtilities.Test/StringExtensionsTests.cs
@@ -67,6 +67,14 @@ namespace WetzUtilities.Test
         }
 
         [Fact]
+        public void ParseTimeTest()
+        {
+            // Note this accounts for daylight savings time; when not active, it's -5 hours.
+            DateTimeOffset? target = new DateTimeOffset(2010,6,30,10, 45,0, new TimeSpan(-4, 0, 0));
+            Assert.Equal(target, "10:45 AM".ParseTime(new DateTime(2010, 6, 30), "Eastern Standard Time"));
+        }
+
+        [Fact]
         public void URLFriendlyTest()
         {
             Assert.Equal("test-phrase", "Test Phrase".URLFriendly()); 

--- a/src/WetzUtilities.Test/WetzUtilities.Test.csproj
+++ b/src/WetzUtilities.Test/WetzUtilities.Test.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WetzUtilities/FileUtilities.cs
+++ b/src/WetzUtilities/FileUtilities.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+Copyright 2020 Peter Wetzel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -25,9 +40,9 @@ namespace WetzUtilities
         /// </summary>
         public static string LoadTextFile(string filePath)
         {
-            if (string.IsNullOrWhiteSpace(filePath))
+            if (filePath.IsEmpty())
             {
-                throw new ArgumentException("File path missing");
+                throw new ArgumentException("File path required", nameof(filePath));
             }
 
             if (!File.Exists(filePath))
@@ -49,9 +64,9 @@ namespace WetzUtilities
         /// </summary>
         public static async Task<string> LoadTextFileAsync(string filePath)
         {
-            if (string.IsNullOrWhiteSpace(filePath))
+            if (filePath.IsEmpty())
             {
-                throw new ArgumentException("File path missing");
+                throw new ArgumentException("File path required", nameof(filePath));
             }
 
             if (!File.Exists(filePath))
@@ -73,14 +88,14 @@ namespace WetzUtilities
         /// </summary>
         public static void WriteTextFile(string dirPath, string fileName, string text)
         {
-            if (string.IsNullOrWhiteSpace(dirPath))
+            if (dirPath.IsEmpty())
             {
-                throw new ArgumentException("Directory missing");
+                throw new ArgumentException("Directory path required", nameof(dirPath));
             }
 
-            if (string.IsNullOrWhiteSpace(fileName))
+            if (fileName.IsEmpty())
             {
-                throw new ArgumentException("File name missing");
+                throw new ArgumentException("File name required", nameof(fileName));
             }
 
             if (!Directory.Exists(dirPath))
@@ -101,14 +116,14 @@ namespace WetzUtilities
         /// </summary>
         public static async Task WriteTextFileAsync(string dirPath, string fileName, string text)
         {
-            if (string.IsNullOrWhiteSpace(dirPath))
+            if (dirPath.IsEmpty())
             {
-                throw new ArgumentException("Directory missing");
+                throw new ArgumentException("Directory path required", nameof(dirPath));
             }
 
-            if (string.IsNullOrWhiteSpace(fileName))
+            if (fileName.IsEmpty())
             {
-                throw new ArgumentException("File name missing");
+                throw new ArgumentException("File name required", nameof(fileName));
             }
 
             if (!Directory.Exists(dirPath))
@@ -130,31 +145,42 @@ namespace WetzUtilities
         /// </summary>
         /// <param name="dirPath">Target directory path (e.g. f:\temp)</param>
         /// <param name="fileName">File name, including extension (e.g. sample.txt)</param>
+        /// <param name="separator">Character used prior to appending number.</param>
         /// <returns></returns>
-        public static string GetNextName(string dirPath, string fileName)
+        public static string GetNextName(string dirPath, string fileName, char separator = '-')
         {
+            if (dirPath.IsEmpty())
+            {
+                throw new ArgumentException("Directory path required", nameof(dirPath));
+            }
+
+            if (fileName.IsEmpty())
+            {
+                throw new ArgumentException("File name required", nameof(fileName));
+            }
+
             var name = Path.GetFileNameWithoutExtension(fileName);
             var extension = Path.GetExtension(fileName);
-            var filePath = Path.Combine(dirPath, name + extension);
+            var filePath = Path.Combine(dirPath, string.Concat(name, extension));
             while (File.Exists(filePath))
             {
-                int index = name.LastIndexOf('-');
+                int index = name.LastIndexOf(separator);
                 if (index < 0)
                 {
-                    name += "-1";
+                    name += $"{separator}1";
                 }
                 else
                 {
                     string val = name.Substring(index + 1);
                     if (!Int32.TryParse(val, out var i))
                     {
-                        name += "-1";
+                        name += $"{separator}1";
                     }
                     else
                     {
                         i++;
                         name = name.Substring(0, index);
-                        name += $"-{i}";
+                        name += $"{separator}{i}";
                     }
                 }
                 filePath = Path.Combine(dirPath, name + extension);

--- a/src/WetzUtilities/LongExtensions.cs
+++ b/src/WetzUtilities/LongExtensions.cs
@@ -1,4 +1,19 @@
-﻿namespace WetzUtilities
+﻿/*
+Copyright 2020 Peter Wetzel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+namespace WetzUtilities
 {
     public static class LongExtensions
     {

--- a/src/WetzUtilities/StringExtensions.cs
+++ b/src/WetzUtilities/StringExtensions.cs
@@ -136,6 +136,22 @@ namespace WetzUtilities
         }
 
         /// <summary>
+        /// Helper method for parsing a time with a given date and time zone.
+        /// If time or date are empty, result will be null.
+        /// </summary>
+        public static DateTimeOffset? ParseTime(this string time, DateTime date, string timeZoneId)
+        {
+            if (time.IsEmpty() || date.IsEmpty())
+            {
+                return null;
+            }
+            var dt = DateTime.Parse($"{date.SafeShortDate()} {time}");
+            var tz = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            var offset = tz.GetUtcOffset(dt);
+            return new DateTimeOffset(dt, offset);
+        }
+
+        /// <summary>
         /// Parses given string into a TimeSpan.
         /// Empty strings result in new TimeSpan.
         /// </summary>

--- a/src/WetzUtilities/StringExtensions.cs
+++ b/src/WetzUtilities/StringExtensions.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright 2019 Peter Wetzel
+Copyright 2020 Peter Wetzel
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -154,7 +154,6 @@ namespace WetzUtilities
                     return TimeSpan.ParseExact(source, @"m\:ss", null);
                 default:
                     return TimeSpan.ParseExact(source, @"ss", null);
-
             }
         }
 

--- a/src/WetzUtilities/WetzUtilities.csproj
+++ b/src/WetzUtilities/WetzUtilities.csproj
@@ -5,13 +5,14 @@
     <Authors>Peter Wetzel</Authors>
     <Company>Peter Wetzel</Company>
     <Description>Common utility methods for .NET projects</Description>
-    <Copyright>(c) 2019 Peter Wetzel</Copyright>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/pdwetz/WetzUtilities/master/LICENSE</PackageLicenseUrl>
+    <Copyright>(c) 2020 Peter Wetzel</Copyright>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/pdwetz/WetzUtilities</PackageProjectUrl>
     <PackageTags>csharp, utilities, strings, datetime, file, guid</PackageTags>
     <RepositoryUrl>https://github.com/pdwetz/WetzUtilities</RepositoryUrl>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- New string extension method ParseTime(), primarily as a helper when dealing with user input for date + time that needs to be time-zone specific.
- GetNextName now allows overriding the separator character (defaults to '-', which is unchanged)
- Added missing license header for some source files as well as some other housecleaning.